### PR TITLE
Renaming overloaded functions to reference type

### DIFF
--- a/steamworksparser.py
+++ b/steamworksparser.py
@@ -60,6 +60,18 @@ g_GameServerInterfaces = (
     'isteamapps.h',
 )
 
+g_TypeNames = {
+    'bool':         'bool',
+    'const char *': 'string',
+    'double *':     'doublePtr',
+    'float *':      'floatPtr',
+    'float':        'float',
+    'int32 *':      'int32Ptr',
+    'int32':        'int32',
+    'int64 *':      'int64Ptr',
+    'int64':        'int64'
+}
+
 class Settings:
     warn_utf8bom = False
     warn_includeguardname = False
@@ -98,6 +110,7 @@ class FunctionAttribute:
 class Function:
     def __init__(self):
         self.name = ""
+        self.originalName = "" # name before overload correction
         self.returntype = ""
         self.args = []  # Arg
         self.ifstatements = []
@@ -109,7 +122,7 @@ class Function:
 class Interface:
     def __init__(self):
         self.name = ""
-        self.functions = []  # Function
+        self.functions = {}  # Function
         self.c = None  # Comment
 
 class Define:
@@ -707,7 +720,7 @@ class Parser:
                     continue
 
             if s.funcState == 1:  # Method Name
-                s.function.name = token.split("(", 1)[0]
+                s.function.originalName = s.function.name = token.split("(", 1)[0]
 
                 if token[-1] == ")":
                     s.funcState = 3
@@ -814,7 +827,24 @@ class Parser:
             if s.funcState == 3:  # = 0; or line
                 if token.endswith(";"):
                     s.funcState = 0
-                    s.interface.functions.append(s.function)
+
+                    prevDecl = s.interface.functions.get(s.function.name)
+                    # if function with same name already exists, find the
+                    # different typed argument in order to rename accordingly
+                    if prevDecl != None:
+                        t1 = None
+                        t2 = None
+                        for i, arg in enumerate(s.function.args):
+                            t1 = arg.type
+                            t2 = prevDecl.args[i].type
+                            if t1 != t2:
+                                break
+                        prevDecl.name = s.function.name + '_' + g_TypeNames[t2]
+                        s.function.name = s.function.name + '_' + g_TypeNames[t1]
+
+                        s.interface.functions[prevDecl.name] = prevDecl
+
+                    s.interface.functions[s.function.name] = s.function
                     s.function = None
                     break
                 continue


### PR DESCRIPTION
When a function got overloaded more than once, the entrypoint method for
fixing it does not work. This method not only fixes it, but it allows
for calling the specific function according to the type needed.