### PR TITLE
Support correctly parsing changes to Steamworks Headers found in 1.57

### DIFF
--- a/steamworksparser.py
+++ b/steamworksparser.py
@@ -492,7 +492,7 @@ class Parser:
         if s.linesplit[0] != "const" and not s.line.startswith("static const"):
             return
 
-        if s.scopeDepth != 0:
+        if s.scopeDepth > 1:
             return
 
         comments = self.consume_comments(s)
@@ -504,6 +504,9 @@ class Parser:
             return
 
         result = re.match(".*const\s+(.*)\s+(\w+)\s+=\s+(.*);$", s.line)
+
+        if not result:
+            return
 
         constant = Constant(result.group(2), result.group(3), result.group(1), comments);
         s.f.constants.append(constant)
@@ -645,7 +648,7 @@ class Parser:
             return
 
         fieldarraysize = None
-        result = re.match("^(.*\s\**)(\w+);$", s.line)
+        result = re.match("^([^=.]*\s\**)(\w+);$", s.line)
         if result is None:
             result = re.match("^(.*\s\*?)(\w+)\[\s*(\w+)?\s*\];$", s.line)
             if result is None:

--- a/steamworksparser.py
+++ b/steamworksparser.py
@@ -664,6 +664,14 @@ class Parser:
             if s.line.startswith("STEAM_CALLBACK_END("):
                 s.f.callbacks.append(s.callbackmacro)
                 s.callbackmacro = None
+            elif s.line.startswith("STEAM_CALLBACK_MEMBER_ARRAY"):
+                result = re.match("^STEAM_CALLBACK_MEMBER_ARRAY\(.*,\s+(.*?)\s*,\s*(\w*)\s*,\s*(\d*)\s*\)", s.line)
+
+                fieldtype = result.group(1)
+                fieldname = result.group(2)
+                fieldarraysize = result.group(3)
+
+                s.callbackmacro.fields.append(StructField(fieldname, fieldtype, fieldarraysize, comments))
             elif s.line.startswith("STEAM_CALLBACK_MEMBER"):
                 result = re.match("^STEAM_CALLBACK_MEMBER\(.*,\s+(.*?)\s*,\s*(\w*)\[?(\d+)?\]?\s*\)", s.line)
 
@@ -672,6 +680,7 @@ class Parser:
                 fieldarraysize = result.group(3)
 
                 s.callbackmacro.fields.append(StructField(fieldname, fieldtype, fieldarraysize, comments))
+            
             else:
                 printWarning("Unexpected line in Callback Macro")
 


### PR DESCRIPTION
Hi there,

We needed to update our Steamworks SDK to 1.57 for Two Point Campus, and in doing so thought we should probably offer the changes required to SteamworksParser back in the form of this pull request.

The first change was to support STEAM_CALLBACK_MEMBER_ARRAY, without this the parser would crash matching the STEAM_CALLBACK_MEMBER string compare but then fail as the regex didn't match.  We now explicitly handle STEAM_CALLBACK_MEMER_ARRAY first and have provided a new regex which matches these.

The second bigger change was required as Valve have declared a new constant within the scope of the GetTicketForWebApiResponse_t callback struct.  The existing struct parsing code was matching this as a field, which then placed it into the C# code inside the struct which obviously isn't valid.  The tweak to the regex to exclude = should hopefully cause any further constants defined like this to be ignored.  In order for the newly defined constant to show up in the constants parsing, it was also necessary to change the scope depth check to also include things at scope depth 1, and then to return out if the regex doesn't match.  As this could significantly affect the generated code, we tested this before and after and were able to confirm that the only changes present to the generated Steamworks.NET api code were the move of this constant to the constants section and the removal of the broken field from the callback struct.

Thanks for all the work in Steamworks.NET - we figured this might either save you some time or be useful for other users who also need to upgrade to 1.57

Cheers

Andrew