### PR TITLE
Add a callback type field to Struct class

### DIFF
--- a/steamworksparser.py
+++ b/steamworksparser.py
@@ -168,6 +168,7 @@ class Struct:
         self.c = comments  # Comment
         self.fields = []  # StructField
         self.callbackid = None
+        self.asyncMarkerInterfaceName = None # string if self is callback
         self.endcomments = None  # Comment
 
 class StructField:


### PR DESCRIPTION
This field is used to generate callback type marker on structs. I will push changed CodeGen later.